### PR TITLE
Upgrade to rand 0.5.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,7 +933,7 @@ dependencies = [
  "pest_derive 1.0.0-beta.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "pm_lib 0.0.0",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.69 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1026,6 +1034,23 @@ dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rand"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rayon"
@@ -1836,6 +1861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
 "checksum clicolors-control 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f84dec9bc083ce2503908cd305af98bd363da6f54bf8d4bf0ac14ee749ad5d1"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "95470235c31c726d72bf2e1f421adc1e65b9d561bf5529612cbe1a72da1467b3"
 "checksum console 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7649ca90478264b9686aac8d269fcb014f14c2bed7c79a7e51b9f6afd4d783eb"
 "checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
@@ -1931,6 +1957,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum rand 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6802c0e883716383777e147b7c21323d5de7527257c8b6dc1365a7f2983e90f6"
+"checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,7 +23,7 @@ indicatif = "0.9.0"
 pest = "=1.0.0-beta.17" # needs update
 pest_derive = "=1.0.0-beta.17" # needs update
 quick-error = "1.2.2"
-rand = "0.4.2" # needs update
+rand = "0.5.3"
 reqwest = "0.8.6"
 rmp-serde = "0.13.7"
 serde = "1.0.69"

--- a/client/src/command/login.rs
+++ b/client/src/command/login.rs
@@ -3,7 +3,7 @@ use std::iter::FromIterator;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use rand::{Rng, OsRng};
+use rand::prelude::random;
 use data_encoding::HEXUPPER;
 use url::{Url, form_urlencoded};
 use webbrowser;
@@ -170,15 +170,15 @@ impl Service for Callback {
     }
 }
 
-pub fn generate_secret() -> Result<String, Error> {
-    let data: Vec<u8> = OsRng::new()?.gen_iter::<u8>().take(32).collect();
-    Ok(HEXUPPER.encode(&data))
+pub fn generate_secret() -> String {
+    let data = random::<[u8; 32]>();
+    HEXUPPER.encode(&data)
 }
 
 pub fn execute(_: Args) -> Result<(), Error> {
     let done = Done::new();
     let callback_done = done.clone();
-    let secret = generate_secret()?;
+    let secret = generate_secret();
     let mut url = Url::parse("http://localhost:8000/login_client").unwrap();
     url.query_pairs_mut().append_pair("token", &secret);
     let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0);


### PR DESCRIPTION
Hey @bodil, I would've pushed this directly but since it's security-sensitive I figure you might want to check it.

The error type on `OsRng::new()` stopped being convertible, but from the [usage examples](https://github.com/rust-lang-nursery/rand#usage) it appears that they just want us to use the [`random()`](https://docs.rs/rand/0.5.3/rand/fn.random.html) function anyway.

`random()` uses [ThreadRng](https://docs.rs/rand/0.5.3/rand/rngs/struct.ThreadRng.html), which they advertise as cryptographically secure, and seems to automatically do the right thing. The documentation for [EntropyRng](https://docs.rs/rand/0.5.3/rand/rngs/struct.EntropyRng.html) seems to steer people away from OsRng/EntropyRng and towards ThreadRng.